### PR TITLE
Fixed PHP 8.2 deprecation warnings: 'creation of dynamic property'.

### DIFF
--- a/library/Zend/Pdf.php
+++ b/library/Zend/Pdf.php
@@ -81,7 +81,6 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-#[\AllowDynamicProperties]
 class Zend_Pdf
 {
   /**** Class Constants ****/
@@ -206,6 +205,13 @@ class Zend_Pdf
      * @var Zend_Pdf_Parser
      */
     protected $_parser;
+
+    /**
+     * PDF version specified in the file header
+     *
+     * @var string
+     */
+    protected $_pdfHeaderVersion;
 
     /**
      * List of inheritable attributesfor pages tree

--- a/library/Zend/Pdf/Action.php
+++ b/library/Zend/Pdf/Action.php
@@ -407,6 +407,6 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
     #[\ReturnTypeWillChange]
     public function count()
     {
-        return count($this->childOutlines);
+        return count($this->next);
     }
 }

--- a/library/Zend/Pdf/Canvas.php
+++ b/library/Zend/Pdf/Canvas.php
@@ -77,7 +77,7 @@ class Zend_Pdf_Canvas extends Zend_Pdf_Canvas_Abstract
      */
     protected function _addProcSet($procSetName)
     {
-        $this->_procset[$procSetName] = 1;
+        $this->_procSet[$procSetName] = 1;
     }
 
     /**

--- a/library/Zend/Pdf/Canvas/Abstract.php
+++ b/library/Zend/Pdf/Canvas/Abstract.php
@@ -74,6 +74,13 @@ abstract class Zend_Pdf_Canvas_Abstract implements Zend_Pdf_Canvas_Interface
      */
     protected $_style = null;
 
+    /**
+     * Page dictionary (refers to an inderect Zend_Pdf_Element_Dictionary object).
+     *
+     * @var Zend_Pdf_Element_Reference|Zend_Pdf_Element_Object
+     */
+    protected $_dictionary;
+
 
     /**
      * Counter for the "Save" operations

--- a/library/Zend/Pdf/Element.php
+++ b/library/Zend/Pdf/Element.php
@@ -46,6 +46,13 @@ abstract class Zend_Pdf_Element
     private $_parentObject = null;
 
     /**
+     * Object value
+     *
+     * @var string
+     */
+    public $value;
+
+    /**
      * Return type of the element.
      * See ZPdfPDFConst for possible values
      *

--- a/library/Zend/Pdf/Element/Boolean.php
+++ b/library/Zend/Pdf/Element/Boolean.php
@@ -35,14 +35,6 @@
 class Zend_Pdf_Element_Boolean extends Zend_Pdf_Element
 {
     /**
-     * Object value
-     *
-     * @var boolean
-     */
-    public $value;
-
-
-    /**
      * Object constructor
      *
      * @param boolean $val

--- a/library/Zend/Pdf/Element/Name.php
+++ b/library/Zend/Pdf/Element/Name.php
@@ -35,14 +35,6 @@
 class Zend_Pdf_Element_Name extends Zend_Pdf_Element
 {
     /**
-     * Object value
-     *
-     * @var string
-     */
-    public $value;
-
-
-    /**
      * Object constructor
      *
      * @param string $val

--- a/library/Zend/Pdf/Element/Null.php
+++ b/library/Zend/Pdf/Element/Null.php
@@ -35,14 +35,6 @@
 class Zend_Pdf_Element_Null extends Zend_Pdf_Element
 {
     /**
-     * Object value. Always null.
-     *
-     * @var mixed
-     */
-    public $value;
-
-
-    /**
      * Object constructor
      */
     public function __construct()

--- a/library/Zend/Pdf/Element/Numeric.php
+++ b/library/Zend/Pdf/Element/Numeric.php
@@ -35,14 +35,6 @@
 class Zend_Pdf_Element_Numeric extends Zend_Pdf_Element
 {
     /**
-     * Object value
-     *
-     * @var numeric
-     */
-    public $value;
-
-
-    /**
      * Object constructor
      *
      * @param numeric $val

--- a/library/Zend/Pdf/Element/Stream.php
+++ b/library/Zend/Pdf/Element/Stream.php
@@ -38,14 +38,6 @@
 class Zend_Pdf_Element_Stream extends Zend_Pdf_Element
 {
     /**
-     * Object value
-     *
-     * @var Zend_Memory_Container
-     */
-    public $value;
-
-
-    /**
      * Object constructor
      *
      * @param string $val

--- a/library/Zend/Pdf/Element/String.php
+++ b/library/Zend/Pdf/Element/String.php
@@ -34,13 +34,6 @@
 class Zend_Pdf_Element_String extends Zend_Pdf_Element
 {
     /**
-     * Object value
-     *
-     * @var string
-     */
-    public $value;
-
-    /**
      * Object constructor
      *
      * @param string $val

--- a/library/Zend/Pdf/Outline.php
+++ b/library/Zend/Pdf/Outline.php
@@ -41,6 +41,49 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
     protected $_open = false;
 
     /**
+     * Outline title.
+     *
+     * @var string
+     */
+    protected $_title;
+
+    /**
+     * True if outline item is displayed in italic.
+     * Default value is false.
+     *
+     * @var boolean
+     */
+    protected $_italic = false;
+
+    /**
+     * Color to be used for the outline entry’s text.
+
+     * It uses the DeviceRGB color space for color representation.
+     * Null means default value - black ([0.0 0.0 0.0] in RGB representation).
+     *
+     * @var Zend_Pdf_Color_Rgb
+     */
+    protected $_color = null;
+
+    /**
+     * True if outline item is displayed in bold.
+     * Default value is false.
+     *
+     * @var boolean
+     */
+    protected $_bold = false;
+
+    /**
+     * Target destination or action.
+     * String means named destination
+     *
+     * Null means no target.
+     *
+     * @var Zend_Pdf_Destination|Zend_Pdf_Action
+     */
+    protected $_target = null;
+
+    /**
      * Array of child outlines (array of Zend_Pdf_Outline objects)
      *
      * @var array

--- a/library/Zend/Pdf/Outline/Created.php
+++ b/library/Zend/Pdf/Outline/Created.php
@@ -44,50 +44,6 @@
 class Zend_Pdf_Outline_Created extends Zend_Pdf_Outline
 {
     /**
-     * Outline title.
-     *
-     * @var string
-     */
-    protected $_title;
-
-    /**
-     * Color to be used for the outline entry’s text.
-
-     * It uses the DeviceRGB color space for color representation.
-     * Null means default value - black ([0.0 0.0 0.0] in RGB representation).
-     *
-     * @var Zend_Pdf_Color_Rgb
-     */
-    protected $_color = null;
-
-    /**
-     * True if outline item is displayed in italic.
-     * Default value is false.
-     *
-     * @var boolean
-     */
-    protected $_italic = false;
-
-    /**
-     * True if outline item is displayed in bold.
-     * Default value is false.
-     *
-     * @var boolean
-     */
-    protected $_bold = false;
-
-    /**
-     * Target destination or action.
-     * String means named destination
-     *
-     * Null means no target.
-     *
-     * @var Zend_Pdf_Destination|Zend_Pdf_Action
-     */
-    protected $_target = null;
-
-
-    /**
      * Get outline title.
      *
      * @return string

--- a/library/Zend/Pdf/Page.php
+++ b/library/Zend/Pdf/Page.php
@@ -110,13 +110,6 @@ class Zend_Pdf_Page extends Zend_Pdf_Canvas_Abstract
 
 
     /**
-     * Page dictionary (refers to an inderect Zend_Pdf_Element_Dictionary object).
-     *
-     * @var Zend_Pdf_Element_Reference|Zend_Pdf_Element_Object
-     */
-    protected $_dictionary;
-
-    /**
      * PDF objects factory.
      *
      * @var Zend_Pdf_ElementFactory_Interface

--- a/library/Zend/Pdf/Resource/Font/CidFont.php
+++ b/library/Zend/Pdf/Resource/Font/CidFont.php
@@ -54,7 +54,6 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-#[\AllowDynamicProperties]
 abstract class Zend_Pdf_Resource_Font_CidFont extends Zend_Pdf_Resource_Font
 {
     /**
@@ -99,7 +98,7 @@ abstract class Zend_Pdf_Resource_Font_CidFont extends Zend_Pdf_Resource_Font
 
         $this->_isBold       = $fontParser->isBold;
         $this->_isItalic     = $fontParser->isItalic;
-        $this->_isMonospaced = $fontParser->isMonospaced;
+        $this->_isMonospace  = $fontParser->isMonospaced;
 
         $this->_underlinePosition  = $fontParser->underlinePosition;
         $this->_underlineThickness = $fontParser->underlineThickness;

--- a/library/Zend/Pdf/Resource/Font/Simple/Parsed.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Parsed.php
@@ -61,7 +61,7 @@ abstract class Zend_Pdf_Resource_Font_Simple_Parsed extends Zend_Pdf_Resource_Fo
 
         $this->_isBold       = $fontParser->isBold;
         $this->_isItalic     = $fontParser->isItalic;
-        $this->_isMonospaced = $fontParser->isMonospaced;
+        $this->_isMonospace  = $fontParser->isMonospaced;
 
         $this->_underlinePosition  = $fontParser->underlinePosition;
         $this->_underlineThickness = $fontParser->underlineThickness;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/Courier.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/Courier.php
@@ -97,7 +97,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_Courier extends Zend_Pdf_Resource_F
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = true;
+        $this->_isMonospace = true;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBold.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBold.php
@@ -98,7 +98,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_CourierBold extends Zend_Pdf_Resour
 
         $this->_isBold = true;
         $this->_isItalic = false;
-        $this->_isMonospaced = true;
+        $this->_isMonospace = true;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBoldOblique.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBoldOblique.php
@@ -99,7 +99,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_CourierBoldOblique extends Zend_Pdf
 
         $this->_isBold = true;
         $this->_isItalic = true;
-        $this->_isMonospaced = true;
+        $this->_isMonospace = true;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierOblique.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierOblique.php
@@ -99,7 +99,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_CourierOblique extends Zend_Pdf_Res
 
         $this->_isBold = false;
         $this->_isItalic = true;
-        $this->_isMonospaced = true;
+        $this->_isMonospace = true;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/Helvetica.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/Helvetica.php
@@ -107,7 +107,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_Helvetica extends Zend_Pdf_Resource
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBold.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBold.php
@@ -107,7 +107,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_HelveticaBold extends Zend_Pdf_Reso
 
         $this->_isBold = true;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBoldOblique.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBoldOblique.php
@@ -110,7 +110,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_HelveticaBoldOblique extends Zend_P
 
         $this->_isBold = true;
         $this->_isItalic = true;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaOblique.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaOblique.php
@@ -109,7 +109,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_HelveticaOblique extends Zend_Pdf_R
 
         $this->_isBold = false;
         $this->_isItalic = true;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/Symbol.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/Symbol.php
@@ -227,7 +227,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_Symbol extends Zend_Pdf_Resource_Fo
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBold.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBold.php
@@ -106,7 +106,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_TimesBold extends Zend_Pdf_Resource
 
         $this->_isBold = true;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBoldItalic.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBoldItalic.php
@@ -107,7 +107,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_TimesBoldItalic extends Zend_Pdf_Re
 
         $this->_isBold = true;
         $this->_isItalic = true;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesItalic.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesItalic.php
@@ -107,7 +107,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_TimesItalic extends Zend_Pdf_Resour
 
         $this->_isBold = false;
         $this->_isItalic = true;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesRoman.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesRoman.php
@@ -107,7 +107,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_TimesRoman extends Zend_Pdf_Resourc
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/ZapfDingbats.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/ZapfDingbats.php
@@ -247,7 +247,7 @@ class Zend_Pdf_Resource_Font_Simple_Standard_ZapfDingbats extends Zend_Pdf_Resou
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/library/Zend/Pdf/Resource/Font/Type0.php
+++ b/library/Zend/Pdf/Resource/Font/Type0.php
@@ -60,7 +60,6 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-#[\AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Type0 extends Zend_Pdf_Resource_Font
 {
     /**
@@ -118,7 +117,7 @@ class Zend_Pdf_Resource_Font_Type0 extends Zend_Pdf_Resource_Font
 
         $this->_isBold       = $descendantFont->isBold();
         $this->_isItalic     = $descendantFont->isItalic();
-        $this->_isMonospaced = $descendantFont->isMonospace();
+        $this->_isMonospace  = $descendantFont->isMonospace();
 
         $this->_underlinePosition  = $descendantFont->getUnderlinePosition();
         $this->_underlineThickness = $descendantFont->getUnderlineThickness();


### PR DESCRIPTION
Fixes deprecation warnings with PHP 8.2: `Creation of dynamic property xxx is deprecated`

Found with phpstan:
1. Have latest version of [phpstan](https://github.com/phpstan/phpstan) installed somewhere (I've used version 1.10.15)
2. Clone this repo
3. Inside the repo, run:
```
$ /path/to/phpstan analyse --level=0 . | grep 'Access to an undefined property'
```
4. Expected to see no errors, but seeing:
```
  331    Access to an undefined property Zend_Pdf::$_pdfHeaderVersion.
  377    Access to an undefined property Zend_Pdf::$_pdfHeaderVersion.
  410    Access to an undefined property Zend_Pdf_Action::$childOutlines.
  80     Access to an undefined property Zend_Pdf_Canvas::$_procset.
  277    Access to an undefined property Zend_Pdf_Canvas_Abstract::$_dictionary.
  136    Access to an undefined property Zend_Pdf_Element::$value.
  158    Access to an undefined property Zend_Pdf_Outline::$_title.
  160    Access to an undefined property Zend_Pdf_Outline::$_color.
  161    Access to an undefined property Zend_Pdf_Outline::$_italic.
  162    Access to an undefined property Zend_Pdf_Outline::$_bold.
  163    Access to an undefined property Zend_Pdf_Outline::$_target.
  102    Access to an undefined property Zend_Pdf_Resource_Font_CidFont::$_isMonospaced.
  64     Access to an undefined property Zend_Pdf_Resource_Font_Simple_Parsed::$_isMonospaced.
  100    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_Courier::$_isMonospaced.
  101    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_CourierBold::$_isMonospaced.
  102    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_CourierBoldOblique::$_isMonospaced.
  102    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_CourierOblique::$_isMonospaced.
  110    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_Helvetica::$_isMonospaced.
  110    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_HelveticaBold::$_isMonospaced.
  113    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_HelveticaBoldOblique::$_isMonospaced.
  112    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_HelveticaOblique::$_isMonospaced.
  230    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_Symbol::$_isMonospaced.
  109    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_TimesBold::$_isMonospaced.
  110    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_TimesBoldItalic::$_isMonospaced.
  110    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_TimesItalic::$_isMonospaced.
  110    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_TimesRoman::$_isMonospaced.
  250    Access to an undefined property Zend_Pdf_Resource_Font_Simple_Standard_ZapfDingbats::$_isMonospaced.
  121    Access to an undefined property Zend_Pdf_Resource_Font_Type0::$_isMonospaced.
```
5. Extra way of testing (not very thouroughly), run inside this repo:
```
$ composer install
```
6. Create a file `test.php` inside the repo with this contents:
```php
<?php

error_reporting(-1);

require_once('vendor/autoload.php');

// test for _isMonospaced problems
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_COURIER);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_COURIER_BOLD);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_COURIER_OBLIQUE);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_COURIER_ITALIC);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_COURIER_BOLD_OBLIQUE);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_COURIER_BOLD_ITALIC);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_HELVETICA);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_HELVETICA_BOLD);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_HELVETICA_OBLIQUE);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_HELVETICA_ITALIC);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_HELVETICA_BOLD_OBLIQUE);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_HELVETICA_BOLD_ITALIC);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_SYMBOL);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_TIMES_ROMAN);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_TIMES);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_TIMES_BOLD);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_TIMES_ITALIC);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_TIMES_BOLD_ITALIC);
\Zend_Pdf_Font::fontWithName(\Zend_Pdf_Font::FONT_ZAPFDINGBATS);

// test for Zend_Pdf problems
new \Zend_Pdf();

// test for Zend_Pdf_Canvas problems
(new \Zend_Pdf_Canvas(100, 100))->setLineWidth(10);

// test for Zend_Pdf_Outline
(new \Zend_Pdf_Outline_Created(['title' => 'test title']))->getOptions();

// tests for Zend_Pdf_Element
var_dump((new \Zend_Pdf_Element_Boolean(true))->toPhp());
var_dump((new \Zend_Pdf_Element_Name('test name'))->toPhp());
var_dump((new \Zend_Pdf_Element_Null())->toPhp());
var_dump((new \Zend_Pdf_Element_Numeric(123))->toPhp());
var_dump((new \Zend_Pdf_Element_Stream('test stream'))->toPhp());
var_dump((new \Zend_Pdf_Element_String('test string'))->toPhp());

// tests for Zend_Pdf_Canvas_Abstract
(new \Zend_Pdf_Page(100, 200))->setStyle(new \Zend_Pdf_Style());
```
7. Execute the `test.php` file using php 8.2 on the command line, expected is to get no deprecation warnings and no new errors after merging this PR.


PR fixes:
- typo's in member names
- wrong member name used
- moves members from lower classes to classes which they extend from


This fixes about half of the warnings mentioned in https://github.com/magento/adobe-commerce-beta/issues/61, If I find more time and this PR actually gets approved, I might try to tackle the others as well one day.