### PR TITLE
Fixed regression from fixing PHP 8.2 deprecated usages earlier, which…

### DIFF
--- a/library/Zend/Pdf/Element.php
+++ b/library/Zend/Pdf/Element.php
@@ -46,13 +46,6 @@ abstract class Zend_Pdf_Element
     private $_parentObject = null;
 
     /**
-     * Object value
-     *
-     * @var string
-     */
-    public $value;
-
-    /**
      * Return type of the element.
      * See ZPdfPDFConst for possible values
      *
@@ -138,10 +131,7 @@ abstract class Zend_Pdf_Element
      *
      * @return mixed
      */
-    public function toPhp()
-    {
-        return $this->value;
-    }
+    abstract public function toPhp();
 
     /**
      * Convert PHP value into PDF element.

--- a/library/Zend/Pdf/Element/Boolean.php
+++ b/library/Zend/Pdf/Element/Boolean.php
@@ -35,6 +35,14 @@
 class Zend_Pdf_Element_Boolean extends Zend_Pdf_Element
 {
     /**
+     * Object value
+     *
+     * @var boolean
+     */
+    public $value;
+
+
+    /**
      * Object constructor
      *
      * @param boolean $val
@@ -71,5 +79,16 @@ class Zend_Pdf_Element_Boolean extends Zend_Pdf_Element
     public function toString($factory = null)
     {
         return $this->value ? 'true' : 'false';
+    }
+
+
+    /**
+     * Convert PDF element to PHP type.
+     *
+     * @return boolean
+     */
+    public function toPhp()
+    {
+        return $this->value;
     }
 }

--- a/library/Zend/Pdf/Element/Name.php
+++ b/library/Zend/Pdf/Element/Name.php
@@ -35,6 +35,14 @@
 class Zend_Pdf_Element_Name extends Zend_Pdf_Element
 {
     /**
+     * Object value
+     *
+     * @var string
+     */
+    public $value;
+
+
+    /**
      * Object constructor
      *
      * @param string $val
@@ -149,5 +157,16 @@ class Zend_Pdf_Element_Name extends Zend_Pdf_Element
     public function toString($factory = null)
     {
         return '/' . self::escape((string)$this->value);
+    }
+
+
+    /**
+     * Convert PDF element to PHP type.
+     *
+     * @return string
+     */
+    public function toPhp()
+    {
+        return $this->value;
     }
 }

--- a/library/Zend/Pdf/Element/Null.php
+++ b/library/Zend/Pdf/Element/Null.php
@@ -35,6 +35,14 @@
 class Zend_Pdf_Element_Null extends Zend_Pdf_Element
 {
     /**
+     * Object value. Always null.
+     *
+     * @var mixed
+     */
+    public $value;
+
+
+    /**
      * Object constructor
      */
     public function __construct()
@@ -63,5 +71,16 @@ class Zend_Pdf_Element_Null extends Zend_Pdf_Element
     public function toString($factory = null)
     {
         return 'null';
+    }
+
+
+    /**
+     * Convert PDF element to PHP type.
+     *
+     * @return mixed
+     */
+    public function toPhp()
+    {
+        return $this->value;
     }
 }

--- a/library/Zend/Pdf/Element/Numeric.php
+++ b/library/Zend/Pdf/Element/Numeric.php
@@ -35,6 +35,14 @@
 class Zend_Pdf_Element_Numeric extends Zend_Pdf_Element
 {
     /**
+     * Object value
+     *
+     * @var numeric
+     */
+    public $value;
+
+
+    /**
      * Object constructor
      *
      * @param numeric $val
@@ -83,5 +91,16 @@ class Zend_Pdf_Element_Numeric extends Zend_Pdf_Element
             $prec++; $v *= 10;
         }
         return sprintf("%.{$prec}F", $this->value);
+    }
+
+
+    /**
+     * Convert PDF element to PHP type.
+     *
+     * @return numeric
+     */
+    public function toPhp()
+    {
+        return $this->value;
     }
 }

--- a/library/Zend/Pdf/Element/Stream.php
+++ b/library/Zend/Pdf/Element/Stream.php
@@ -38,6 +38,14 @@
 class Zend_Pdf_Element_Stream extends Zend_Pdf_Element
 {
     /**
+     * Object value
+     *
+     * @var Zend_Memory_Container
+     */
+    public $value;
+
+
+    /**
      * Object constructor
      *
      * @param string $val
@@ -118,5 +126,15 @@ class Zend_Pdf_Element_Stream extends Zend_Pdf_Element
     public function toString($factory = null)
     {
         return "stream\n" . $this->value->getRef() . "\nendstream";
+    }
+
+    /**
+     * Convert PDF element to PHP type.
+     *
+     * @return Zend_Memory_Container
+     */
+    public function toPhp()
+    {
+        return $this->value;
     }
 }

--- a/library/Zend/Pdf/Element/String.php
+++ b/library/Zend/Pdf/Element/String.php
@@ -34,6 +34,13 @@
 class Zend_Pdf_Element_String extends Zend_Pdf_Element
 {
     /**
+     * Object value
+     *
+     * @var string
+     */
+    public $value;
+
+    /**
      * Object constructor
      *
      * @param string $val
@@ -64,6 +71,17 @@ class Zend_Pdf_Element_String extends Zend_Pdf_Element
     public function toString($factory = null)
     {
         return '(' . self::escape((string)$this->value) . ')';
+    }
+
+
+    /**
+     * Convert PDF element to PHP type.
+     *
+     * @return string
+     */
+    public function toPhp()
+    {
+        return $this->value;
     }
 
 


### PR DESCRIPTION
… broke rendering certain elements in a pdf in Magento

This fixes a regression bug that was created in #1 
The bug is described here: https://github.com/magento/magento2/issues/37897

I can not really explain how it triggers, it's very weird and unexpected. But reverting the `$value` member back to each individual child class and removing it again from the parent `Zend_Pdf_Element` class fixes the problem.

In order to fix the PHP 8.2 deprecated usage of `this->value` in `Zend_Pdf_Element`, I turned the `toPhp` function into an abstract function which forces the classes that inherit from it to implement it, so I did that. It's a bit of duplicated code each time, but can't find a better way to solve it. At least the return types in docblocks will be more correct now for the `toPhp` function ...

(the double new lines in between methods is to stay consistent with the coding style of the original code)