### PR TITLE
Fixes PHP 8.5 deprecation with sending values to 'chr' function that …

### DIFF
--- a/library/Zend/Pdf/Filter/Compression.php
+++ b/library/Zend/Pdf/Filter/Compression.php
@@ -219,8 +219,7 @@ abstract class Zend_Pdf_Filter_Compression implements Zend_Pdf_Filter_Interface
                         $lastSample = array_fill(0, $bytesPerSample, 0);
                         for ($count2 = 0; $count2 < $bytesPerRow; $count2++) {
                             $newByte = ord($data[$offset++]);
-                            // Note. chr() automatically cuts input to 8 bit
-                            $output .= chr($newByte - $lastSample[$count2 % $bytesPerSample]);
+                            $output .= chr(($newByte - $lastSample[$count2 % $bytesPerSample]) & 0xFF);
                             $lastSample[$count2 % $bytesPerSample] = $newByte;
                         }
                     }
@@ -233,8 +232,7 @@ abstract class Zend_Pdf_Filter_Compression implements Zend_Pdf_Filter_Interface
 
                         for ($count2 = 0; $count2 < $bytesPerRow; $count2++) {
                             $newByte = ord($data[$offset++]);
-                            // Note. chr() automatically cuts input to 8 bit
-                            $output .= chr($newByte - $lastRow[$count2]);
+                            $output .= chr(($newByte - $lastRow[$count2]) & 0xFF);
                             $lastRow[$count2] = $newByte;
                         }
                     }
@@ -248,8 +246,7 @@ abstract class Zend_Pdf_Filter_Compression implements Zend_Pdf_Filter_Interface
                         $lastSample = array_fill(0, $bytesPerSample, 0);
                         for ($count2 = 0; $count2 < $bytesPerRow; $count2++) {
                             $newByte = ord($data[$offset++]);
-                            // Note. chr() automatically cuts input to 8 bit
-                            $output .= chr($newByte - floor(( $lastSample[$count2 % $bytesPerSample] + $lastRow[$count2])/2));
+                            $output .= chr(($newByte - floor(($lastSample[$count2 % $bytesPerSample] + $lastRow[$count2]) / 2)) & 0xFF);
                             $lastSample[$count2 % $bytesPerSample] = $lastRow[$count2] = $newByte;
                         }
                     }
@@ -264,11 +261,12 @@ abstract class Zend_Pdf_Filter_Compression implements Zend_Pdf_Filter_Interface
                         $lastSample = array_fill(0, $bytesPerSample, 0);
                         for ($count2 = 0; $count2 < $bytesPerRow; $count2++) {
                             $newByte = ord($data[$offset++]);
-                            // Note. chr() automatically cuts input to 8 bit
-                            $output .= chr($newByte - self::_paeth( $lastSample[$count2 % $bytesPerSample],
-                                                                    $lastRow[$count2],
-                                                                    ($count2 - $bytesPerSample  <  0)?
-                                                                         0 : $lastRow[$count2 - $bytesPerSample] ));
+                            $output .= chr(
+                                ($newByte - self::_paeth(
+                                    $lastSample[$count2 % $bytesPerSample],
+                                    $lastRow[$count2],
+                                    ($count2 - $bytesPerSample <  0) ? 0 : ($lastRow[$count2 - $bytesPerSample])
+                                )) & 0xFF);
                             $lastSample[$count2 % $bytesPerSample] = $currentRow[$count2] = $newByte;
                         }
                         $lastRow = $currentRow;


### PR DESCRIPTION
…are outside allowed bounds (0 => 255)

PHP 8.5 deprecated sending values to `chr` function that are outside of the allowed bounds. See [docs](https://www.php.net/manual/en/function.chr.php):
> Passing integers outside the interval [0, 255] is now deprecated.

We can fix this by masking the values with a bitwise operation: `& 0xFF`
See the following for a small demonstration this works and no longer triggers a deprecation warning on PHP 8.5:  https://3v4l.org/LnHdMv#v



See https://github.com/magento/magento-zend-pdf/issues/6#issuecomment-4951441116 for steps to reproduce this bug in Magento and to verify if this PR fixes it.

